### PR TITLE
Fix documentation logo to use master branch version

### DIFF
--- a/docs_src/docs/index.md
+++ b/docs_src/docs/index.md
@@ -1,6 +1,7 @@
 <p align="center">
-    <a href="https://pri.meight.com"><img width=256 height=256 src="https://raw.githubusercontent.com/wearemeight/primeight/initial-version/docs_src/docs/images/logo-with-name.svg" alt="Primeight"></a>
+    <a href="https://pri.meight.com"><img width=256 height=256 src="https://raw.githubusercontent.com/wearemeight/primeight/master/docs_src/docs/images/logo-with-name.svg" alt="Primeight"></a>
 </p>
+
 ***
 
 **primeight** is a Python package designed to make the powerful NoSQL [Cassandra](https://cassandra.apache.org/) database system easily available to everyone. 


### PR DESCRIPTION
The documentation logo is still using the previous `initial-version` branch, I changed it to master to fix the problem. 