### PR TITLE
Map is not recognized as a collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-##  [0.1.1] - 2020-09-22
+## [0.1.3] - 2021-01-07
+
+### Changed
+- fix bug where map was not recognized as a collection by the parser
+- fix bug where parser would crash if the `backup` field was not defined
+
+## [0.1.2] - 2020-09-29
+
+### Changed
+- improve PyPi primeight page
+
+## [0.1.1] - 2020-09-22
 
 ### Added
 - initial version.

--- a/primeight/parser/parser.py
+++ b/primeight/parser/parser.py
@@ -161,6 +161,7 @@ class Parser:
                 .replace('list<', '') \
                 .replace('tuple<', '') \
                 .replace('set<', '') \
+                .replace('map<', '') \
                 .strip('>')
             # Validate that the column type is recognized.
             if ',' in t:


### PR DESCRIPTION
When using a `map` type in a YAML configuration file the parser raises `SyntaxError: Unrecognized type`.